### PR TITLE
fix: panic on empty headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Fix panic on headers that contain no text.
+
 ## 0.1.0 - 2023-02-04
 
 - Initial release.

--- a/transform.go
+++ b/transform.go
@@ -196,6 +196,12 @@ func (t *transform) transform(h *ast.Heading) {
 		n.SetAttributeString(name, []byte(value))
 	}
 
+	// If the header has no children yet, just append the anchor.
+	if h.ChildCount() == 0 {
+		h.AppendChild(h, n)
+		return
+	}
+
 	if t.Position == Before {
 		h.InsertBefore(h, h.FirstChild(), n)
 	} else {

--- a/transform_test.go
+++ b/transform_test.go
@@ -119,6 +119,21 @@ func TestTransform(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "no title yet",
+			give: []string{
+				"#",
+				"",
+			},
+			want: []*anchor{
+				{
+					ID:       "heading",
+					Level:    1,
+					Value:    defaultValue,
+					Position: After,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -208,11 +223,11 @@ func TestTransform_badIDAttribute(t *testing.T) {
 }
 
 func findAnchor(h *ast.Heading) (an *Node, pos Position) {
-	if an, ok := h.FirstChild().(*Node); ok {
-		return an, Before
-	}
 	if an, ok := h.LastChild().(*Node); ok {
 		return an, After
+	}
+	if an, ok := h.FirstChild().(*Node); ok {
+		return an, Before
 	}
 	return nil, 0
 }


### PR DESCRIPTION
If a header has no text,
that is it's just this:

    ##

It's parsed as a header without any child nodes.
That causes a panic with InsertBefore or InsertAfter.

So if a heading does not contain any children,
just append the anchor to it.
