### PR TITLE
Add demo website

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,4 +1,4 @@
-name: Publish API Reference
+name: Publish documentation
 
 on:
   # Publish documentation when a new release is tagged.
@@ -40,6 +40,10 @@ jobs:
         run: go install go.abhg.dev/doc2go@latest
       - name: Generate API reference
         run: doc2go -home go.abhg.dev/goldmark/anchor ./...
+      - name: Build demo website
+        run: |
+          make -C demo
+          cp -r demo/static _site/demo
       - name: Upload pages
         uses: actions/upload-pages-artifact@v1
 

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -1,0 +1,12 @@
+OUT = static
+
+.PHONY: all
+all: $(OUT)/wasm_exec.js $(OUT)/main.wasm
+
+$(OUT)/wasm_exec.js:
+	@mkdir -p $(OUT)
+	cp "$(shell go env GOROOT)/misc/wasm/wasm_exec.js" $@
+
+$(OUT)/main.wasm: $(wildcard *.go)
+	@mkdir -p $(OUT)
+	GOOS=js GOARCH=wasm go build -o $@

--- a/demo/go.mod
+++ b/demo/go.mod
@@ -1,0 +1,10 @@
+module go.abhg.dev/goldmark/anchor/demo
+
+go 1.20
+
+replace go.abhg.dev/goldmark/anchor => ../
+
+require (
+	github.com/yuin/goldmark v1.5.3
+	go.abhg.dev/goldmark/anchor v0.1.0
+)

--- a/demo/go.sum
+++ b/demo/go.sum
@@ -1,0 +1,6 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/yuin/goldmark v1.5.3 h1:3HUJmBFbQW9fhQOzMgseU134xfi6hU+mjWywx5Ty+/M=
+github.com/yuin/goldmark v1.5.3/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/demo/main.go
+++ b/demo/main.go
@@ -1,0 +1,48 @@
+// demo implements a WASM module that can be used to format markdown
+// with the goldmark-anchor extension.
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"syscall/js"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/parser"
+	"go.abhg.dev/goldmark/anchor"
+)
+
+func main() {
+	js.Global().Set("formatMarkdown", js.FuncOf(formatMarkdown))
+	select {}
+}
+
+func formatMarkdown(this js.Value, args []js.Value) any {
+	input := args[0].Get("markdown").String()
+	var pos anchor.Position
+	switch s := args[0].Get("position").String(); s {
+	case "before":
+		pos = anchor.Before
+	case "after":
+		pos = anchor.After
+	default:
+		return fmt.Sprintf("invalid position: %q", s)
+	}
+
+	md := goldmark.New(
+		goldmark.WithParserOptions(
+			parser.WithAutoHeadingID(),
+		),
+		goldmark.WithExtensions(
+			&anchor.Extender{
+				Position: pos,
+			},
+		),
+	)
+
+	var buf bytes.Buffer
+	if err := md.Convert([]byte(input), &buf); err != nil {
+		return err.Error()
+	}
+	return buf.String()
+}

--- a/demo/static/.gitignore
+++ b/demo/static/.gitignore
@@ -1,0 +1,2 @@
+/wasm_exec.js
+/main.wasm

--- a/demo/static/index.html
+++ b/demo/static/index.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>goldmark-anchor</title>
+    <script src="wasm_exec.js"></script>
+    <script>
+      const go = new Go();
+      WebAssembly.instantiateStreaming(fetch("main.wasm"), go.importObject).then((result) => {
+        go.run(result.instance);
+      });
+    </script>
+    <style>
+      body {
+        font-family: sans-serif;
+      }
+      .container {
+        max-width: 100%;
+        margin: 0 auto;
+        position: relative;
+      }
+      .input-container {
+        border: 1px solid #ccc;
+        padding: 1em;
+        top: 0;
+        left: 0;
+        width: 45%;
+        position: absolute;
+      }
+      .output-container {
+        border: 1px solid #ccc;
+        padding: 1em;
+        top: 0;
+        left: 50%;
+        width: 45%;
+        position: absolute;
+      }
+
+      #input {
+        width: 100%;
+        height: 60vh;
+      }
+
+      a.anchor { text-decoration: none; }
+    </style>
+  </head>
+  <body>
+    <center>
+      <h1><a href="https://github.com/abhinav/goldmark-anchor">goldmark-anchor</a></h1>
+    </center>
+
+    <div class="container">
+      <div class="input-container">
+        <h2>Input</h2>
+        <textarea id="input" rows="10" cols="80"></textarea>
+
+        <label for="position">Position</label>
+        <select id="position" active="after">
+          <option value="before">Before</option>
+          <option value="after" selected>After</option>
+        </select>
+      </div>
+
+      <div class="output-container">
+        <h2>Output</h2>
+        <div id="output"></div>
+      </div>
+    </div>
+  </body>
+
+  <script>
+    const input = document.getElementById("input");
+    const output = document.getElementById("output");
+    const position = document.getElementById("position");
+
+    input.addEventListener("input", refresh);
+    position.addEventListener("change", refresh);
+
+    function refresh() {
+      output.innerHTML = formatMarkdown({
+        markdown: input.value,
+        position: position.value,
+      });
+    }
+  </script>
+</html>


### PR DESCRIPTION
Adds a demo website to the documentation.
The demo website uses WASM to allow previewing the plugin output
on a static web page.
