### PR TITLE
feat: add Renderer.Unsafe

### DIFF
--- a/extend.go
+++ b/extend.go
@@ -35,6 +35,13 @@ type Extender struct {
 	//
 	// Defaults to adding a 'class="anchor"' attribute.
 	Attributer Attributer
+
+	// Unsafe specifies whether the Texter values will be escaped or not.
+	// Setting this to true can lead to HTML injection if you don't handle
+	// Texter values with care.
+	//
+	// Defaults to false.
+	Unsafe bool
 }
 
 var _ goldmark.Extender = (*Extender)(nil)
@@ -54,6 +61,7 @@ func (e *Extender) Extend(md goldmark.Markdown) {
 		renderer.WithNodeRenderers(
 			util.Prioritized(&Renderer{
 				Position: e.Position,
+				Unsafe:   e.Unsafe,
 			}, 100),
 		),
 	)

--- a/render.go
+++ b/render.go
@@ -12,6 +12,9 @@ type Renderer struct {
 	// Position specifies where in the header text
 	// the anchor is being added.
 	Position Position
+	// Unsafe specifies whether the Texter values will be HTML escaped or
+	// not.
+	Unsafe bool
 }
 
 var _ renderer.NodeRenderer = (*Renderer)(nil)
@@ -49,7 +52,11 @@ func (r *Renderer) RenderNode(w util.BufWriter, _ []byte, node ast.Node, enterin
 	_, _ = w.WriteString(` href="#`)
 	_, _ = w.Write(util.EscapeHTML(n.ID))
 	_, _ = w.WriteString(`">`)
-	_, _ = w.Write(util.EscapeHTML(n.Value))
+	if r.Unsafe {
+		_, _ = w.Write(n.Value)
+	} else {
+		_, _ = w.Write(util.EscapeHTML(n.Value))
+	}
 	_, _ = w.WriteString("</a>")
 
 	return ast.WalkContinue, nil

--- a/render_test.go
+++ b/render_test.go
@@ -14,11 +14,12 @@ func TestRenderer(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		desc  string
-		give  Node
-		attrs map[string]string
-		pos   Position
-		want  string
+		desc   string
+		give   Node
+		attrs  map[string]string
+		pos    Position
+		want   string
+		unsafe bool
 	}{
 		{desc: "empty ID"},
 		{
@@ -47,6 +48,25 @@ func TestRenderer(t *testing.T) {
 			attrs: map[string]string{"foo": "bar"},
 			want:  ` <a foo="bar" href="#hello">#</a>`,
 		},
+		{
+			desc: "attributes",
+			give: Node{
+				ID:    []byte("hello"),
+				Value: []byte("<unsafe></unsafe>"),
+			},
+			attrs: map[string]string{"foo": "bar"},
+			want:  ` <a foo="bar" href="#hello">&lt;unsafe&gt;&lt;/unsafe&gt;</a>`,
+		},
+		{
+			desc: "attributes",
+			give: Node{
+				ID:    []byte("hello"),
+				Value: []byte("<unsafe></unsafe>"),
+			},
+			attrs:  map[string]string{"foo": "bar"},
+			want:   ` <a foo="bar" href="#hello"><unsafe></unsafe></a>`,
+			unsafe: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -56,6 +76,7 @@ func TestRenderer(t *testing.T) {
 
 			anchorR := Renderer{
 				Position: tt.pos,
+				Unsafe:   tt.unsafe,
 			}
 			r := renderer.NewRenderer(
 				renderer.WithNodeRenderers(


### PR DESCRIPTION
Sanitization of Value means that we can't set Texter to custom HTML code like a `<svg>` icon for example. It can lead to HTML injection if user input is added to the Texter without proper sanitization, so add a new Renderer.Unsafe option (default to false) that can disable the sanitization if needed.